### PR TITLE
Fixed converting non-text content to latex-content

### DIFF
--- a/private/unmap.rkt
+++ b/private/unmap.rkt
@@ -81,7 +81,9 @@
           [(delayed-element? e) (error "unsupported")]
           [(part-relative-element? e) (error "unsupported")]
           [(list? e) (map recur e)]
-          [else (error 'content->latex-content "non-content ~a" e0)])))
+          ;; e0 must be a content, and the only remaining contents seem to be pictures.
+          ;; A picture cannot have latex content; return it.
+          [else e0])))
 
 (define-syntax-rule (unmath e1 e ...) (parameterize ([math-mode #f]) e1 e ...))
 (define-syntax-rule (in-math e1 e ...) (parameterize ([math-mode #t]) e1 e ...))


### PR DESCRIPTION
Pictures are valid content, but were not correctly handled by 
content->latex-content.
Since content->latex-content has a contract, we can remove this error
check and assume any content that is not already handled is a picture
and thus can be directly embedded.