### PR TITLE
fix a package confict, \openbox.

### DIFF
--- a/scribble/tex/amsthm.tex
+++ b/scribble/tex/amsthm.tex
@@ -1,3 +1,6 @@
+\ifdefined\openbox
+  \let\openbox\relax
+\fi
 \usepackage{amsthm}
 \newtheorem{definition}{Definition}
 \newtheorem{theorem}{Theorem}


### PR DESCRIPTION
Newer versions of `newtxmath`, which is used in Scribble-generated latex preambles, define \openbox. As a general suggestion, we undefine the \openbox before amsthem is imported.